### PR TITLE
replace deprecated method res.send

### DIFF
--- a/server/api/db-connect.js
+++ b/server/api/db-connect.js
@@ -10,7 +10,7 @@ const DB_URL = `${process.env.DATABASE_URL}?ssl=true`;
 module.exports = function(res, cb) {
   pg.connect(DB_URL, (err, client, done) => {
     if (err) {
-      res.send(500, {
+      res.status(500).send({
         errors: [generateErrors.genericError()]
       });
       console.error(err);


### PR DESCRIPTION
My console showing `express deprecated res.send(status, body): Use res.status(status).send(body)`