### PR TITLE
Revert "Refactor to use async-await (#142)"

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "stage-3", "react"]
+  "presets": ["es2015", "react"]
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "babel-polyfill": "^6.3.14",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
-    "babel-preset-stage-3": "^6.5.0",
     "babel-register": "^6.3.13",
     "chai": "^3.4.1",
     "del": "^2.2.0",

--- a/test/setup/node.js
+++ b/test/setup/node.js
@@ -5,7 +5,6 @@ global.sinon = require('sinon');
 global.chai.use(require('sinon-chai'));
 
 require('babel-core/register');
-require('babel-polyfill');
 require('./setup')();
 
 /*


### PR DESCRIPTION
This reverts commit 2eba1ec4b658bf8479957bd01558b8607c907bf7.

===

I'm glad I tried this out – and I'm a big fan of it – but I'm not a fan of what I need to do to get this working in regular old Node. Afaik my options are:

- Use the [asyncawait](https://github.com/yortus/asyncawait) library (seems a bit heavy/syntax isn't 100% the same)
- Precompile server side JS (no ty)
- Use babel/register on the server (bad practice!)

So for now...au revoir, async await.