### PR TITLE
Update concatenate-inserts.js

### DIFF
--- a/test/integration/api/utils/concatenate-inserts.js
+++ b/test/integration/api/utils/concatenate-inserts.js
@@ -1,7 +1,5 @@
 import pg from 'pg-promise';
 
-const pgp = pg();
-
 // Concatenates an array of objects or arrays of values, according to the template,
 // to use with insert queries. Can be used either as a class type or as a function.
 //
@@ -13,7 +11,7 @@ function Inserts(template, data) {
   }
   this._rawDBType = true;
   this.formatDBType = function() {
-    return data.map(d => `(${pgp.as.format(template, d)})`).join(',');
+    return data.map(d => `(${pg.as.format(template, d)})`).join(',');
   };
 }
 


### PR DESCRIPTION
namespace `as` is available from the library's root also, the same as all the other global data types.